### PR TITLE
[Breaking Change] Remove import of dragula css

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This Ember addon provides support for drag and drop using [dragula](https://beva
 ## Installation
 
 ```
-ember install @zestia/ember-dragula
+ember install @zestia/ember-dragula dragula
 ```
 
 Add the following to `~/.npmrc` to pull @zestia scoped packages from Github instead of NPM.
@@ -23,6 +23,12 @@ Add the following to `~/.npmrc` to pull @zestia scoped packages from Github inst
 ```
 @zestia:registry=https://npm.pkg.github.com
 //npm.pkg.github.com/:_authToken=<YOUR_GH_TOKEN>
+```
+
+Add this line to `app/app.js` to import the base `dragula` styles:
+
+```
+import 'dragula/dist/dragula.css';
 ```
 
 ## Demo

--- a/index.js
+++ b/index.js
@@ -13,6 +13,5 @@ module.exports = {
 
   included(app) {
     this._super.included.apply(this, arguments);
-    app.import('node_modules/dragula/dist/dragula.css');
   }
 };


### PR DESCRIPTION
Fixes https://github.com/zestia/ember-dragula/issues/29

This will (probably) be a breaking change for apps that use this add-on.

To fix the breakage:

* `ember install dragula`
* Add this line to `app/app.js`:
```
import 'dragula/dist/dragula.css';
```