### PR TITLE
Workaround the `global` problem in `dragula`

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "main": "addon-main.cjs",
     "app-js": {
       "./components/dragula-container.js": "./dist/_app_/components/dragula-container.js",
-      "./components/dragula.js": "./dist/_app_/components/dragula.js"
+      "./components/dragula.js": "./dist/_app_/components/dragula.js",
+      "./components/global-fix.js": "./dist/_app_/components/global-fix.js"
     }
   },
   "imports": {

--- a/src/components/dragula.gjs
+++ b/src/components/dragula.gjs
@@ -1,3 +1,4 @@
+import '@zestia/ember-dragula/components/global-fix';
 import Component from '@glimmer/component';
 import DragulaContainer from '@zestia/ember-dragula/components/dragula-container';
 import dragula from 'dragula';

--- a/src/components/global-fix.gjs
+++ b/src/components/global-fix.gjs
@@ -1,0 +1,3 @@
+
+console.log('hello')
+globalThis.global = globalThis;

--- a/src/components/global-fix.gjs
+++ b/src/components/global-fix.gjs
@@ -1,3 +1,3 @@
-
-console.log('hello')
+// This is here to work around a bug in dragula:
+// https://github.com/bevacqua/dragula/issues/602#issuecomment-1917936901
 globalThis.global = globalThis;


### PR DESCRIPTION
Fixes this problem: https://github.com/zestia/ember-dragula/issues/29#issuecomment-3202183949

And is an alternate to this PR: https://github.com/zestia/ember-dragula/pull/33

This is mostly a proof of concept to show that we can address the problem from within the add-on. I'm not sure that `components/global-fix` is the best path for that file to live at. I'm open to suggestions on how it should be organized. (The reason that there's a whole new file is that all `import` statements get hoisted to the top of the file during the build step, so we can't just apply the fix before `import`ing from `dragula`, but we can `import` our own file before `import`ing from `dragula`.)